### PR TITLE
Single Export Config Warning

### DIFF
--- a/field_group.module
+++ b/field_group.module
@@ -26,7 +26,7 @@ function field_group_config_info() {
 function field_group_config_label($config, $config_name) {
   list($group_name, $entity_type_name, $bundle, $mode) = explode('.', str_replace('field_group.field_group.', '', $config_name));
   $entity_type = entity_get_info($entity_type_name);
-  $entity_label = $entity_type['label'];
+  $entity_label = isset($entity_type['label']) ? $entity_type['label'] : $entity_type;
   $bundle_label = isset($entity_type['bundles'][$bundle]['label']) ? $entity_type['bundles'][$bundle]['label'] : $bundle;
 
   return $entity_label . ' - ' . $bundle_label . ' - Mode: ' . $mode . ' - ' . $group_name;

--- a/field_group.module
+++ b/field_group.module
@@ -24,9 +24,9 @@ function field_group_config_info() {
  * Given a bundle config file, display a unique label.
  */
 function field_group_config_label($config, $config_name) {
-  list($group_name, $entity_type_name, $bundle, $mode) = explode('.', str_replace('field_group.field_group.', '', $config_name));
+  list($entity_type_name, $bundle, $mode, $group_name) = explode('.', str_replace('field_group.field_group.', '', $config_name));
   $entity_type = entity_get_info($entity_type_name);
-  $entity_label = isset($entity_type['label']) ? $entity_type['label'] : $entity_type;
+  $entity_label = $entity_type['label'];
   $bundle_label = isset($entity_type['bundles'][$bundle]['label']) ? $entity_type['bundles'][$bundle]['label'] : $bundle;
 
   return $entity_label . ' - ' . $bundle_label . ' - Mode: ' . $mode . ' - ' . $group_name;


### PR DESCRIPTION
There is a warning being thrown when navigating to the single config export. I have looked at the field_group.module file and the warning is coming from line 29. I have added logic to the variable being set so that the warning is no longer being logged.