### PR TITLE
Fixes #50: Add support for entity_plus

### DIFF
--- a/field_group.module
+++ b/field_group.module
@@ -200,6 +200,11 @@ function field_group_theme_registry_alter(&$theme_registry) {
     $entities[] = 'entity';
   }
 
+  // Support for Entity Plus API.
+  if (isset($theme_registry['entity_plus'])) {
+    $entities[] = 'entity_plus';
+  }
+
   foreach ($entities as $entity) {
     if (isset($theme_registry[$entity])) {
       $theme_registry[$entity]['preprocess functions'][] = 'field_group_build_entity_groups';


### PR DESCRIPTION
Fixes #50 
Modules that use entity_plus call entity_plus_view rather than entity_view, so we need to add explicit support in the hook_theme_registry_alter. This allows field groups to be used with modules such as field_collection.