### PR TITLE
Fix for attribute names and = getting stripped

### DIFF
--- a/field_group.groups.inc
+++ b/field_group.groups.inc
@@ -279,8 +279,8 @@ function field_group_pre_render_html_element(&$element, $group, &$form) {
   }
 
   // Sanitize the attributes.
-  $element_attributes = _filter_xss_attributes(backdrop_attributes($element_attributes));
-  $attributes = $element_attributes ? ' ' . implode(' ', $element_attributes) : '';
+  $element_attributes = backdrop_attributes(filter_xss_attributes($element_attributes));
+  $attributes = $element_attributes ? ' ' . $element_attributes : '';
 
   $element['#prefix'] = '<' . $html_element . $attributes . '>';
   if ($show_label) {

--- a/field_group.groups.inc
+++ b/field_group.groups.inc
@@ -279,8 +279,15 @@ function field_group_pre_render_html_element(&$element, $group, &$form) {
   }
 
   // Sanitize the attributes.
-  $element_attributes = backdrop_attributes(filter_xss_attributes($element_attributes));
-  $attributes = $element_attributes ? ' ' . $element_attributes : '';
+  if (function_exists('filter_xss_attributes')) {
+    // Function introduced in 1.30.x.
+    $attributes = backdrop_attributes(filter_xss_attributes($element_attributes));
+  }
+  else {
+    // Assume using core < 1.30.x.
+    $element_attributes = _filter_xss_attributes(backdrop_attributes($element_attributes));
+    $attributes = $element_attributes ? ' ' . implode(' ', $element_attributes) : '';
+  }
 
   $element['#prefix'] = '<' . $html_element . $attributes . '>';
   if ($show_label) {


### PR DESCRIPTION
Attributes like 'class="foo"' were having the element name and = getting stripped from the output becomming just "foo". This was because of a change to _filter_xss_attributes in Backdrop core. They added a new filter_xss_attributes function that I think we can use instead to get the same effect.

Fixes #55.