### PR TITLE
Issue #1: alternative to dropbuttons

### DIFF
--- a/css/field_group.field_ui.css
+++ b/css/field_group.field_ui.css
@@ -17,15 +17,15 @@ tr.field-group input.form-submit {
   float: none;
 }
 
-#field-display-overview input.field-formatter-settings-edit,
-#field-overview input.field-formatter-settings-edit {
+#field-display-overview input.field-group-formatter-settings-edit,
+#field-overview input.field-group-formatter-settings-edit {
   border: 0;
   box-shadow: none;
   padding: 0.4em 1em;
   line-height: 1.2;
 }
 
-.field-formatter-settings-delete {
+.field-group-formatter-settings-delete {
   display: block;
   padding: 0.4em 1em;
   line-height: 1.2;

--- a/css/field_group.field_ui.css
+++ b/css/field_group.field_ui.css
@@ -20,6 +20,7 @@ tr.field-group input.form-submit {
 #field-display-overview input.field-group-formatter-settings-edit,
 #field-overview input.field-group-formatter-settings-edit {
   border: 0;
+  border-radius: unset;
   box-shadow: none;
   padding: 0.4em 1em;
   line-height: 1.2;
@@ -87,8 +88,7 @@ tr.field-group input.form-submit {
 }
 
 .field-group-formatter-settings-edit-wrapper .details-child-wrapper > * {
-  margin-left: 0;
-  margin-right: 0;
+  margin: 0;
 }
 
 #field-overview .field-group-formatter-settings-edit-wrapper .details-child-wrapper > *:first-child,

--- a/css/field_group.field_ui.css
+++ b/css/field_group.field_ui.css
@@ -17,12 +17,86 @@ tr.field-group input.form-submit {
   float: none;
 }
 
-#field-display-overview .field-formatter-settings-edit-wrapper a {
-  display: block;
-}
-
+#field-display-overview input.field-formatter-settings-edit,
 #field-overview input.field-formatter-settings-edit {
-  margin: 0;
+  border: 0;
+  box-shadow: none;
   padding: 0.4em 1em;
   line-height: 1.2;
+}
+
+.field-formatter-settings-delete {
+  display: block;
+  padding: 0.4em 1em;
+  line-height: 1.2;
+  text-align: center;
+  cursor: pointer;
+}
+
+.field-group-formatter-settings-edit-wrapper {
+  position: relative;
+  border: 0;
+  border-radius: unset;
+  margin: 0;
+  background-color: transparent;
+  overflow: visible;
+}
+
+.field-group-formatter-settings-edit-wrapper summary {
+  text-transform: uppercase;
+  border: 0;
+  list-style: none;
+
+  span {
+    font-size: inherit;
+  }
+}
+
+.field-group-formatter-settings-edit-wrapper .details-child-wrapper {
+  position: absolute;
+  right: 0;
+  display: block;
+  z-index: 100;
+  background: #fff;
+  border-radius: 4px;
+  border: 2px solid #ccc;
+  margin-top: 5px;
+  box-shadow: 0 0 4px #ddd;
+}
+
+.field-group-formatter-settings-edit-wrapper .details-child-wrapper:before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: auto;
+  right: 17px;
+  top: -18px;
+  border: 9px solid transparent;
+  border-bottom: 9px solid #ccc;
+}
+
+.field-group-formatter-settings-edit-wrapper .details-child-wrapper:after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: auto;
+  right: 18px;
+  top: -14px;
+  border: 8px solid transparent;
+  border-bottom: 8px solid #fff;
+}
+
+.field-group-formatter-settings-edit-wrapper .details-child-wrapper > * {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+#field-overview .field-group-formatter-settings-edit-wrapper .details-child-wrapper > *:first-child,
+#field-display-overview .field-group-formatter-settings-edit-wrapper .details-child-wrapper > *:first-child {
+  margin-top: 0.5em;
+}
+
+#field-overview .field-group-formatter-settings-edit-wrapper .details-child-wrapper > *:last-child,
+#field-display-overview .field-group-formatter-settings-edit-wrapper .details-child-wrapper > *:last-child {
+  margin-bottom: 0.5em;
 }

--- a/field_group.field_ui.inc
+++ b/field_group.field_ui.inc
@@ -264,7 +264,7 @@ function field_group_field_ui_overview_form_alter(&$form, &$form_state, $display
         '#type' => 'submit',
         '#name' => $name . '_group_settings_edit',
         '#value' => t('Configure'),
-        '#attributes' => array('class' => array('field-formatter-settings-edit', 'button-secondary'), 'alt' => t('Configure')),
+        '#attributes' => array('class' => array('field-formatter-settings-edit', 'field-group-formatter-settings-edit', 'button-secondary'), 'alt' => t('Configure')),
         '#op' => 'edit',
         // Do not check errors for the 'Configure' button.
         '#limit_validation_errors' => array(),
@@ -273,7 +273,7 @@ function field_group_field_ui_overview_form_alter(&$form, &$form_state, $display
         '#type' => 'link',
         '#title' => t('Delete'),
         '#href' => '',
-        '#attributes' => array('class' => array('field-formatter-settings-delete')),
+        '#attributes' => array('class' => array('field-group-formatter-settings-delete')),
       );
       if ($display_overview) {
         $table[$name]['settings_edit']['delete']['#href'] = $params->admin_path . '/groups/' . $name . '/delete/' . $params->mode;

--- a/field_group.field_ui.inc
+++ b/field_group.field_ui.inc
@@ -247,28 +247,40 @@ function field_group_field_ui_overview_form_alter(&$form, &$form_state, $display
       }
       // Add the configure button.
       $table[$name]['settings_edit'] = array(
-        '#type' => 'container',
-        '#attributes' => array('class' => array('field-formatter-settings-edit-wrapper')),
+        '#type' => 'details',
+        '#summary' => icon('dots-three-outline-fill', array(
+          'alt' => t('Configure'),
+          'attributes' => array(
+            'width' => 22,
+            'height' => 22,
+          ),
+        )),
+        '#attributes' => array(
+          'class' => array('field-formatter-settings-edit-wrapper', 'field-group-formatter-settings-edit-wrapper'),
+          'aria-label' => t('Configure'),
+        ),
       );
       $table[$name]['settings_edit']['edit'] = $base_button + array(
         '#type' => 'submit',
         '#name' => $name . '_group_settings_edit',
         '#value' => t('Configure'),
-        '#attributes' => array('class' => array('field-formatter-settings-edit button-secondary'), 'alt' => t('Configure')),
+        '#attributes' => array('class' => array('field-formatter-settings-edit', 'button-secondary'), 'alt' => t('Configure')),
         '#op' => 'edit',
         // Do not check errors for the 'Configure' button.
         '#limit_validation_errors' => array(),
       );
+      $table[$name]['settings_edit']['delete'] = array(
+        '#type' => 'link',
+        '#title' => t('Delete'),
+        '#href' => '',
+        '#attributes' => array('class' => array('field-formatter-settings-delete')),
+      );
       if ($display_overview) {
-        $table[$name]['settings_edit']['delete'] = array(
-          '#markup' => l(t('Delete'), $params->admin_path . '/groups/' . $name . '/delete/' . $params->mode),
-        );
+        $table[$name]['settings_edit']['delete']['#href'] = $params->admin_path . '/groups/' . $name . '/delete/' . $params->mode;
       }
     }
     if (!$display_overview) {
-      $table[$name]['settings_edit']['delete'] = array(
-        '#markup' => l(t('Delete'), $params->admin_path . '/groups/' . $name . '/delete/form'),
-      );
+      $table[$name]['settings_edit']['delete']['#href'] = $params->admin_path . '/groups/' . $name . '/delete/form';
     }
   }
 

--- a/js/field_group.field_ui.js
+++ b/js/field_group.field_ui.js
@@ -134,4 +134,40 @@ Backdrop.fieldUIDisplayOverview.group.prototype = {
 
 };
 
+/**
+ * Process field group actions elements.
+ *
+ * @type {Backdrop~behavior}
+ *
+ * @prop {Backdrop~behaviorAttach} attach
+ *   Attaches field-groupActions behaviors.
+ */
+Backdrop.behaviors.fieldgroupActions = {
+  attach: function (context, settings) {
+    var $actionsElement = $('.field-group-formatter-settings-edit-wrapper').once('field-group-formatter-settings-edit-wrapper', context);
+    // Attach event handlers to toggle button.
+    $actionsElement.each(function () {
+      var $this = $(this);
+
+      $this.on('focusout', function (e) {
+        setTimeout(function () {
+          if ($this.has(document.activeElement).length == 0) {
+            // The focus left the action button group, hide actions.
+            $this.removeAttr('open');
+          }
+        }, 1);
+      });
+    });
+    $(document).on('keydown.fieldgroupActions', function (event) {
+      if (event.key === 'Escape') {
+        $('.field-group-formatter-settings-edit-wrapper').removeAttr('open');
+      }
+    });
+
+  },
+  detach: function (context) {
+    $(document).off('keydown.fieldgroupActions');
+  }
+};
+
 })(jQuery);


### PR DESCRIPTION
Resolves #1.

I took a different approach; changed the container into a `<details>` and using CSS (borrowing from Paragraphs actions buttons):

Display mode:
<img width="490" height="272" alt="2026-01-14 10 28 34 bd-2 lndo site 463a96b35849" src="https://github.com/user-attachments/assets/bc6ec36c-541f-4a9b-a469-68d9f35890e0" />

Fields:
<img width="478" height="264" alt="2026-01-14 10 28 15 bd-2 lndo site cb39a4ed9a08" src="https://github.com/user-attachments/assets/cd225456-4051-4b22-9ed1-dd64b9b9cada" />

