### PR TITLE
Issue #85: separate out div into extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Available group types:
 * Fieldset
 * [HTML Details](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details)
 * Vertical tabs
-* Div
-* HTML element
+* HTML element - tags like `<section>`, `<footer>`, `<div>`
 
 Field Group has API functions to add your own formatter and rendering for it.
 
@@ -30,8 +29,9 @@ Update
 ------
 
 Some group types have been moved to a separate module [Field Group Extra](https://backdropcms.org/project/field_group_extra).
-Install that module if you require: accordions, horizontal tabs or multipage
-group types.
+Install that module if you require: accordions, horizontal tabs, multipages, or
+collapsible divs. Note that you can simulate accordions by using details
+elements and giving each details the same name attribute.
 
 License
 -------

--- a/field_group.groups.inc
+++ b/field_group.groups.inc
@@ -24,17 +24,6 @@ function _field_group_field_group_formatter_info() {
           'required_fields' => 1, 'id' => '',
         ),
       ),
-      'div' => array(
-        'label' => t('Div'),
-        'description' => t('This field group renders the inner content in a simple div with the title as legend.'),
-        'format_types' => array('open', 'collapsible', 'collapsed'),
-        'instance_settings' => array(
-          'description' => '', 'show_label' => 1, 'label_element' => 'h3',
-          'effect' => 'none', 'speed' => 'fast', 'classes' => '',
-          'required_fields' => 1, 'id' => '',
-        ),
-        'default_formatter' => 'open',
-      ),
       'fieldset' => array(
         'label' => t('Fieldset'),
         'description' => t('This field group renders the inner content in a fieldset with the title as legend.'),
@@ -81,16 +70,6 @@ function _field_group_field_group_formatter_info() {
           'classes' => '', 'attributes' => '',
           'required_fields' => 1, 'id' => '',
         ),
-      ),
-      'div' => array(
-        'label' => t('Div'),
-        'description' => t('This field group renders the inner content in a simple div with the title as legend.'),
-        'format_types' => array('open', 'collapsible', 'collapsed'),
-        'instance_settings' => array(
-          'description' => '', 'show_label' => 1, 'label_element' => 'h3',
-          'effect' => 'none', 'speed' => 'fast', 'classes' => '', 'id' => '',
-        ),
-        'default_formatter' => 'open',
       ),
       'fieldset' => array(
         'label' => t('Fieldset'),
@@ -252,52 +231,6 @@ function field_group_pre_render_html_element(array &$element, $group, array &$fo
     $element['#prefix'] .= '<div class="description">' . $group->description . '</div>';
   }
   $element['#suffix'] = '</' . $html_element . '>';
-}
-
-/**
- * Implements field_group_pre_render_<format-type>.
- * Format type: Div.
- *
- * @param array $element
- *   The field group form element.
- * @param object $group
- *   The Field group object prepared for pre_render.
- * @param array $form
- *   The root element or form.
- */
-function field_group_pre_render_div(array &$element, $group, array &$form) {
-
-  $show_label = isset($group->format_settings['instance_settings']['show_label']) ? $group->format_settings['instance_settings']['show_label'] : 0;
-  $label_element = isset($group->format_settings['instance_settings']['label_element']) ? $group->format_settings['instance_settings']['label_element'] : 'h2';
-  $effect = isset($group->format_settings['instance_settings']['effect']) ? $group->format_settings['instance_settings']['effect'] : 'none';
-
-  $element['#type'] = 'markup';
-  $id = isset($element['#id']) ? ' id="' . $element['#id'] . '"' : '';
-
-  if ($group->format_settings['formatter'] != 'open') {
-
-    $element['#prefix'] = '<div' . $id . ' class="' . $group->classes . '">
-      <' . $label_element . '><span class="field-group-format-toggler">' . check_plain(t($group->label)) . '</span></' . $label_element . '>
-      <div class="field-group-format-wrapper" style="display: ' . (!empty($group->collapsed) ? 'none' : 'block') . ';">';
-    $element['#suffix'] = '</div></div>';
-  }
-  else {
-    $class_attribute = !empty($group->classes) ? ' class="' . $group->classes . '"' : '';
-
-    $element['#prefix'] = '<div' . $id . $class_attribute . '>';
-    if ($show_label) {
-      $element['#prefix'] .= '<' . $label_element . ' class="field-group-label"><span>' . check_plain(t($group->label)) . '</span></' . $label_element . '>';
-    }
-    $element['#suffix'] = '</div>';
-  }
-  if (!empty($group->description)) {
-    $element['#prefix'] .= '<div class="description">' . $group->description . '</div>';
-  }
-
-  if ($effect == 'blind') {
-    $element['#attached']['library'][] = array('system', 'effects.blind');
-  }
-
 }
 
 /**
@@ -531,46 +464,6 @@ function _field_group_field_group_format_settings_alter(&$form, &$group) {
         '#weight' => 5,
       );
       break;
-    case 'div':
-      $form['label']['#description'] = t('Please enter a label for collapsible elements');
-      $form['instance_settings']['show_label'] = array(
-        '#title' => t('Show label'),
-        '#type' => 'select',
-        '#options' => array(0 => t('No'), 1 => t('Yes')),
-        '#default_value' => isset($group->format_settings['instance_settings']['show_label']) ? $group->format_settings['instance_settings']['show_label'] : $formatter['instance_settings']['show_label'],
-        '#weight' => 2,
-      );
-      $form['instance_settings']['label_element'] = array(
-        '#title' => t('Label element'),
-        '#type' => 'select',
-        '#options' => array('h2' => t('Header 2'), 'h3' => t('Header 3')),
-        '#default_value' => isset($group->format_settings['instance_settings']['label_element']) ? $group->format_settings['instance_settings']['label_element'] : $formatter['instance_settings']['label_element'],
-        '#weight' => 3,
-        '#states' => array(
-          'visible' => array(
-            'select[name="' . $select_name . '[show_label]"]' => array('value' => 1),
-          ),
-        ),
-      );
-      $form['instance_settings']['effect'] = array(
-        '#title' => t('Effect'),
-        '#description' => t('The effect to use if collapsible.'),
-        '#type' => 'select',
-        '#options' => array('none' => t('None'), 'blind' => t('Blind')),
-        '#default_value' => isset($group->format_settings['instance_settings']['effect']) ? $group->format_settings['instance_settings']['effect'] : $formatter['instance_settings']['effect'],
-        '#weight' => 4,
-      );
-      $form['instance_settings']['speed'] = array(
-        '#title' => t('Speed'),
-        '#description' => t('The speed of the effect if collapsible.'),
-        '#type' => 'select',
-        '#options' => array(
-          'none' => t('None'), 'slow' => t('Slow'), 'fast' => t('Fast'),
-        ),
-        '#default_value' => isset($group->format_settings['instance_settings']['speed']) ? $group->format_settings['instance_settings']['speed'] : $formatter['instance_settings']['speed'],
-        '#weight' => 5,
-      );
-      break;
     case 'fieldset':
       $form['label']['#description'] = t('Please enter a label for collapsible elements');
       break;
@@ -684,19 +577,5 @@ function _field_group_field_group_html_classes_alter(&$classes, &$group) {
   // Open or closed horizontal or vertical tabs will be collapsible by default.
   if ($group->format_type == 'tab') {
     $classes->required[] = 'collapsible';
-  }
-
-  if (isset($group->format_settings['instance_settings'])) {
-    // Extra required classes for div.
-    if ($group->format_type == 'div') {
-      if ($group->format_settings['formatter'] != 'open') {
-
-        $speed = isset($group->format_settings['instance_settings']['speed']) ? $group->format_settings['instance_settings']['speed'] : 'none';
-        $classes->required[] = 'speed-' . $speed;
-
-        $effect = isset($group->format_settings['instance_settings']['effect']) ? $group->format_settings['instance_settings']['effect'] : 'none';
-        $classes->required[] = 'effect-' . $effect;
-      }
-    }
   }
 }

--- a/field_group.install
+++ b/field_group.install
@@ -68,6 +68,9 @@ function _field_group_extra_status() {
   foreach ($field_groups as $field_group) {
     $config = config($field_group);
     if (in_array($config->get('format_type'), $extra_types)) {
+      if ($config->get('format_type') == 'div' && $config->get('format_settings.formatter') == 'open') {
+        continue;
+      }
       $extras_enabled = TRUE;
       break;
     }
@@ -141,17 +144,9 @@ function field_group_update_1001() {
 
 /**
  * Warn that field_group_extra module needs to be downloaded and installed
- * if Accordion, Horizontal Tabs, and Multipage types are enabled.
+ * if Accordion, Div, Horizontal Tabs, and Multipage types are enabled.
  */
 function field_group_update_1002() {
-  // Empty in favour of field_group_update_1003().
-}
-
-/**
- * Warn that field_group_extra module needs to be downloaded and installed
- * if Accordion, Div, Horizonal Tabs, and Multipage types are enabled.
- */
-function field_group_update_1003() {
   list($extras_module, $extras_enabled) = _field_group_extra_status();
 
   if ($extras_enabled) {
@@ -188,6 +183,30 @@ function field_group_update_1003() {
       else {
         $field_group_config->set('format_settings.instance_settings.label_element_other', '');
       }
+    }
+    $field_group_config->save();
+  }
+}
+
+/**
+ * Merge Div format type into the HTML Element format type, if it is simple.
+ * That is, if the display is not set to collapsible or collapsed, it can be
+ * safely converted.
+ */
+function field_group_update_1004() {
+  $config_names = config_get_names_with_prefix('field_group.field_group.');
+  foreach ($config_names as $config_name) {
+    $field_group_config = config($config_name);
+    if ($field_group_config->get('format_type') == 'div' && $field_group_config->get('formatter') != 'open') {
+      $field_group_config->set('format_type', 'html-element');
+      $field_group_config->set('format_settings.instance_settings.wrapper', 'div');
+      $field_group_config->set('format_settings.instance_settings.wrapper_other', '');
+      $field_group_config->set('format_settings.instance_settings.label_element_other', '');
+
+      // Clear unused settings.
+      $field_group_config->clear('format_settings.formatter');
+      $field_group_config->clear('format_settings.instance_settings.effect');
+      $field_group_config->clear('format_settings.instance_settings.speed');
     }
     $field_group_config->save();
   }

--- a/field_group.install
+++ b/field_group.install
@@ -189,15 +189,14 @@ function field_group_update_1003() {
 }
 
 /**
- * Merge Div format type into the HTML Element format type, if it is simple.
- * That is, if the display is not set to collapsible or collapsed, it can be
- * safely converted.
+ * Merge Div format type into the HTML Element format type, if the display is
+ * not set to collapsible or collapsed. It can be safely converted.
  */
 function field_group_update_1004() {
   $config_names = config_get_names_with_prefix('field_group.field_group.');
   foreach ($config_names as $config_name) {
     $field_group_config = config($config_name);
-    if ($field_group_config->get('format_type') == 'div' && $field_group_config->get('formatter') != 'open') {
+    if ($field_group_config->get('format_type') == 'div' && $field_group_config->get('format_settings.formatter') == 'open') {
       $field_group_config->set('format_type', 'html-element');
       $field_group_config->set('format_settings.instance_settings.wrapper', 'div');
       $field_group_config->set('format_settings.instance_settings.wrapper_other', '');

--- a/field_group.install
+++ b/field_group.install
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Field group module install file.
@@ -19,10 +18,10 @@ function field_group_requirements($phase) {
     if ($extras_enabled && !$extras_module) {
       if ($extras_module === FALSE) {
         // Module not found.
-        $message = $t('The <em>Accordion</em>, <em>Horizontal tabs</em>, or <em>Multipage</em> field group types are used on this site. The contrib module !module should be downloaded and enabled to ensure the existing field groups continue to work properly. Or update those field groups to use other group types.', array('!module' => l('Field Group Extra', 'https://backdropcms.org/project/field_group_extra')));
+        $message = $t('The <em>Accordion</em>, <em>Div</em>, <em>Horizontal tabs</em>, or <em>Multipage</em> field group types are used on this site. The contrib module !module should be downloaded and enabled to ensure the existing field groups continue to work properly. Or update those field groups to use other group types.', array('!module' => l('Field Group Extra', 'https://backdropcms.org/project/field_group_extra')));
       } elseif (!$extras_module) {
         // Module exists but isn't enabled.
-      $message = $t('The <em>Accordion</em>, <em>Horizontal tabs</em>, or <em>Multipage</em> field group types are used on this site. The contrib module %module should be enabled to ensure the existing field groups continue to work properly. Or update those field groups to use other group types.', array('%module' => 'Field Group Extra'));
+      $message = $t('The <em>Accordion</em>, <em>Div</em>, <em>Horizontal tabs</em>, or <em>Multipage</em> field group types are used on this site. The contrib module %module should be enabled to ensure the existing field groups continue to work properly. Or update those field groups to use other group types.', array('%module' => 'Field Group Extra'));
       }
       $requirements['field_group_extra'] = array(
         'title' => $t('Field Group Extra'),
@@ -56,12 +55,15 @@ function _field_group_extra_status() {
   $extras_enabled = FALSE;
   $field_groups = config_get_names_with_prefix('field_group.field_group.');
   $extra_types = array(
+    // cspell:disable
     'accordion',
     'accordion-item',
+    'div',
     'htab',
     'htabs',
     'multipage',
     'multipage-group',
+    // cspell:enable
   );
   foreach ($field_groups as $field_group) {
     $config = config($field_group);
@@ -139,17 +141,24 @@ function field_group_update_1001() {
 
 /**
  * Warn that field_group_extra module needs to be downloaded and installed
- * if Accordion, Horizonal Tabs, and Multipage types are enabled.
+ * if Accordion, Horizontal Tabs, and Multipage types are enabled.
  */
 function field_group_update_1002() {
+  // Empty in favour of field_group_update_1003().
+}
+
+/**
+ * Warn that field_group_extra module needs to be downloaded and installed
+ * if Accordion, Div, Horizonal Tabs, and Multipage types are enabled.
+ */
+function field_group_update_1003() {
   list($extras_module, $extras_enabled) = _field_group_extra_status();
 
   if ($extras_enabled) {
     if ($extras_module === FALSE) {
       // Module not found.
-      backdrop_set_message(t('The <em>Accordion</em>, <em>Horizontal tabs</em>, and <em>Multipage</em> field group types have been moved out of the Field Group module. The contrib module !module should be downloaded and enabled to ensure the existing field groups continue to work properly. Or update those field groups to use other group types.', array('!module' => l('Field Group Extra', 'https://backdropcms.org/project/field_group_extra'))));
-    }
-    elseif (!$extras_module) {
+      backdrop_set_message(t('The <em>Accordion</em>, <em>Div</em>, <em>Horizontal tabs</em>, and <em>Multipage</em> field group types have been moved out of the Field Group module. The contrib module !module should be downloaded and enabled to ensure the existing field groups continue to work properly. Or update those field groups to use other group types.', array('!module' => l('Field Group Extra', 'https://backdropcms.org/project/field_group_extra'))));
+    } elseif (!$extras_module) {
       // Module exists but isn't enabled.
       db_update('system')
         ->fields(array('status' => 1))

--- a/js/field_groups.js
+++ b/js/field_groups.js
@@ -87,60 +87,6 @@ Backdrop.FieldGroup.Effects.processTabs = {
 }
 
 /**
- * Implements Backdrop.FieldGroup.processHook().
- *
- * TODO clean this up meaning check if this is really  necessary.
- */
-Backdrop.FieldGroup.Effects.processDiv = {
-  execute: function (context, settings, type) {
-
-    $('div.collapsible', context).once('fieldgroup-effects', function() {
-      var $wrapper = $(this);
-
-      // Turn the legend into a clickable link, but retain span.field-group-format-toggler
-      // for CSS positioning.
-
-      var $toggler = $('span.field-group-format-toggler:first', $wrapper);
-      var $link = $('<a class="field-group-format-title" href="#"></a>');
-      $link.prepend($toggler.contents());
-
-      // Add required field markers if needed
-      if ($(this).is('.required-fields') && $(this).find('.form-required').length > 0) {
-        $link.append(' ').append($('.form-required').eq(0).clone());
-      }
-
-      $link.appendTo($toggler);
-
-      // .wrapInner() does not retain bound events.
-      $link.click(function () {
-        var wrapper = $wrapper.get(0);
-        // Don't animate multiple times.
-        if (!wrapper.animating) {
-          wrapper.animating = true;
-          var speed = $wrapper.hasClass('speed-fast') ? 300 : 1000;
-          if ($wrapper.hasClass('effect-none') && $wrapper.hasClass('speed-none')) {
-            $('> .field-group-format-wrapper', wrapper).toggle();
-            wrapper.animating = false;
-          }
-          else if ($wrapper.hasClass('effect-blind')) {
-            $('> .field-group-format-wrapper', wrapper).toggle('blind', {}, speed);
-            wrapper.animating = false;
-          }
-          else {
-            $('> .field-group-format-wrapper', wrapper).toggle(speed, function() {
-              wrapper.animating = false;
-            });
-          }
-        }
-        $wrapper.toggleClass('collapsed');
-        return false;
-      });
-
-    });
-  }
-};
-
-/**
  * Behaviors.
  */
 Backdrop.behaviors.fieldGroups = {
@@ -150,12 +96,12 @@ Backdrop.behaviors.fieldGroups = {
     $('.fieldset-wrapper .fieldset > legend').css({ display: 'block' });
     $('.vertical-tabs fieldset.fieldset').addClass('default-fallback');
 
-    // Fieldsets: set the hash in url to remember last userselection.
+    // Fieldsets: set the hash in url to remember last user selection.
     $('.group-wrapper ul li').once('group-wrapper-ul-processed', function() {
       var fieldGroupNavigationListIndex = $(this).index();
       $(this).children('a').click(function() {
         var fieldset = $('.group-wrapper fieldset').get(fieldGroupNavigationListIndex);
-        // Grab the first id, holding the wanted hashurl.
+        // Grab the first id, holding the wanted hash url.
         var hashUrl = $(fieldset).attr('id').replace(/^field_group-/, '').split(' ')[0];
         window.location.hash = hashUrl;
       });


### PR DESCRIPTION
Fixes #85 

alternative: move out div instead of html-element, because it's got weird js to make it collapsible, which is not majority use case. Also improves html-element settings a bit.

Should probably add an update hook that could convert `div` to `html-element` if "collapsible" is not enabled.